### PR TITLE
Overriding public key acceptance and known hosts issues

### DIFF
--- a/src/Tasks/ShipTask.php
+++ b/src/Tasks/ShipTask.php
@@ -60,6 +60,8 @@ class ShipTask extends Tasks implements TaskInterface
     public function run()
     {
         return $this->taskSshExec($this->ip, $this->remote_user)
+            ->option('-o', 'StrictHostKeyChecking=no')
+            ->option('-o', 'UserKnownHostsFile=/dev/null')
             ->exec($this->shipper->pullImage($this->image, $this->sudo))
             ->exec($this->shipper->runContainer(
                 $this->image,


### PR DESCRIPTION
Overriding public key acceptance and known hosts issues so that we can ssh into a new server without the connection hanging.

We may want to consider changing this to a `-f` flag in the future.
